### PR TITLE
Add template printing API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,7 +13,30 @@ import (
 
 	"github.com/oapi-codegen/runtime"
 	strictnethttp "github.com/oapi-codegen/runtime/strictmiddleware/nethttp"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
+
+// Defines values for DeviceState.
+const (
+	BUSY         DeviceState = "BUSY"
+	CONNECTING   DeviceState = "CONNECTING"
+	DISCONNECTED DeviceState = "DISCONNECTED"
+	OUTOFPAPER   DeviceState = "OUT_OF_PAPER"
+	READY        DeviceState = "READY"
+)
+
+// DeviceInfo defines model for DeviceInfo.
+type DeviceInfo struct {
+	// BatteryLevel Battery level of device as a percentage
+	BatteryLevel int `json:"batteryLevel"`
+
+	// FirmwareVersion Device specific firmware version string
+	FirmwareVersion string      `json:"firmwareVersion"`
+	State           DeviceState `json:"state"`
+}
+
+// DeviceState defines model for DeviceState.
+type DeviceState string
 
 // Position defines model for Position.
 type Position struct {
@@ -23,6 +46,7 @@ type Position struct {
 
 // Template defines model for Template.
 type Template struct {
+	Id         *int                 `json:"id,omitempty"`
 	Images     *[]TemplateImage     `json:"images,omitempty"`
 	Landscape  bool                 `json:"landscape"`
 	Name       string               `json:"name"`
@@ -54,11 +78,29 @@ type TemplateText struct {
 	Width    *int     `json:"width,omitempty"`
 }
 
+// PrintImageJSONBody defines parameters for PrintImage.
+type PrintImageJSONBody struct {
+	ContentType string             `json:"contentType"`
+	Data        openapi_types.File `json:"data"`
+}
+
+// PrintImageJSONRequestBody defines body for PrintImage for application/json ContentType.
+type PrintImageJSONRequestBody PrintImageJSONBody
+
 // CreateTemplateJSONRequestBody defines body for CreateTemplate for application/json ContentType.
 type CreateTemplateJSONRequestBody = Template
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Print an image directly
+	// (POST /printer)
+	PrintImage(w http.ResponseWriter, r *http.Request)
+	// Get device info
+	// (GET /printer/info)
+	GetPrinterInfo(w http.ResponseWriter, r *http.Request)
+	// List templates
+	// (GET /template)
+	ListTemplate(w http.ResponseWriter, r *http.Request)
 	// Create a new template
 	// (POST /template)
 	CreateTemplate(w http.ResponseWriter, r *http.Request)
@@ -75,6 +117,48 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// PrintImage operation middleware
+func (siw *ServerInterfaceWrapper) PrintImage(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PrintImage(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetPrinterInfo operation middleware
+func (siw *ServerInterfaceWrapper) GetPrinterInfo(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetPrinterInfo(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListTemplate operation middleware
+func (siw *ServerInterfaceWrapper) ListTemplate(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListTemplate(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // CreateTemplate operation middleware
 func (siw *ServerInterfaceWrapper) CreateTemplate(w http.ResponseWriter, r *http.Request) {
@@ -235,10 +319,85 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc("POST "+options.BaseURL+"/printer", wrapper.PrintImage)
+	m.HandleFunc("GET "+options.BaseURL+"/printer/info", wrapper.GetPrinterInfo)
+	m.HandleFunc("GET "+options.BaseURL+"/template", wrapper.ListTemplate)
 	m.HandleFunc("POST "+options.BaseURL+"/template", wrapper.CreateTemplate)
 	m.HandleFunc("GET "+options.BaseURL+"/template/{id}", wrapper.GetTemplate)
 
 	return m
+}
+
+type PrintImageRequestObject struct {
+	Body *PrintImageJSONRequestBody
+}
+
+type PrintImageResponseObject interface {
+	VisitPrintImageResponse(w http.ResponseWriter) error
+}
+
+type PrintImage202Response struct {
+}
+
+func (response PrintImage202Response) VisitPrintImageResponse(w http.ResponseWriter) error {
+	w.WriteHeader(202)
+	return nil
+}
+
+type PrintImage422Response struct {
+}
+
+func (response PrintImage422Response) VisitPrintImageResponse(w http.ResponseWriter) error {
+	w.WriteHeader(422)
+	return nil
+}
+
+type PrintImage503Response struct {
+}
+
+func (response PrintImage503Response) VisitPrintImageResponse(w http.ResponseWriter) error {
+	w.WriteHeader(503)
+	return nil
+}
+
+type GetPrinterInfoRequestObject struct {
+}
+
+type GetPrinterInfoResponseObject interface {
+	VisitGetPrinterInfoResponse(w http.ResponseWriter) error
+}
+
+type GetPrinterInfo200JSONResponse DeviceInfo
+
+func (response GetPrinterInfo200JSONResponse) VisitGetPrinterInfoResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetPrinterInfo503Response struct {
+}
+
+func (response GetPrinterInfo503Response) VisitGetPrinterInfoResponse(w http.ResponseWriter) error {
+	w.WriteHeader(503)
+	return nil
+}
+
+type ListTemplateRequestObject struct {
+}
+
+type ListTemplateResponseObject interface {
+	VisitListTemplateResponse(w http.ResponseWriter) error
+}
+
+type ListTemplate200JSONResponse []Template
+
+func (response ListTemplate200JSONResponse) VisitListTemplateResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type CreateTemplateRequestObject struct {
@@ -292,6 +451,15 @@ func (response GetTemplate404Response) VisitGetTemplateResponse(w http.ResponseW
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// Print an image directly
+	// (POST /printer)
+	PrintImage(ctx context.Context, request PrintImageRequestObject) (PrintImageResponseObject, error)
+	// Get device info
+	// (GET /printer/info)
+	GetPrinterInfo(ctx context.Context, request GetPrinterInfoRequestObject) (GetPrinterInfoResponseObject, error)
+	// List templates
+	// (GET /template)
+	ListTemplate(ctx context.Context, request ListTemplateRequestObject) (ListTemplateResponseObject, error)
 	// Create a new template
 	// (POST /template)
 	CreateTemplate(ctx context.Context, request CreateTemplateRequestObject) (CreateTemplateResponseObject, error)
@@ -327,6 +495,85 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// PrintImage operation middleware
+func (sh *strictHandler) PrintImage(w http.ResponseWriter, r *http.Request) {
+	var request PrintImageRequestObject
+
+	var body PrintImageJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PrintImage(ctx, request.(PrintImageRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PrintImage")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PrintImageResponseObject); ok {
+		if err := validResponse.VisitPrintImageResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetPrinterInfo operation middleware
+func (sh *strictHandler) GetPrinterInfo(w http.ResponseWriter, r *http.Request) {
+	var request GetPrinterInfoRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetPrinterInfo(ctx, request.(GetPrinterInfoRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetPrinterInfo")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetPrinterInfoResponseObject); ok {
+		if err := validResponse.VisitGetPrinterInfoResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListTemplate operation middleware
+func (sh *strictHandler) ListTemplate(w http.ResponseWriter, r *http.Request) {
+	var request ListTemplateRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListTemplate(ctx, request.(ListTemplateRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListTemplate")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListTemplateResponseObject); ok {
+		if err := validResponse.VisitListTemplateResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // CreateTemplate operation middleware

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Phogoprint API
-  version: 1.0.0
+  version: 0.1.0
 
 servers:
   - url: http://localhost:8080
@@ -53,6 +53,41 @@ paths:
                 $ref: "#/components/schemas/Template"
         "404":
           description: Template not found
+  /template/{id}/print:
+    post:
+      summary: Print a template
+      operationId: PrintTemplate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PrintTemplateRequest"
+      responses:
+        "202":
+          description: Printer successfully printed
+        "404":
+          description: No such template
+        "422":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - reason
+                properties:
+                  reason:
+                    type: string
+                    example: Missing parameter "address"
+        "503":
+          description: Printer unavailable
   /printer:
     post:
       summary: Print an image directly
@@ -120,6 +155,8 @@ components:
       required:
         - name
         - landscape
+        - minSize
+        - maxSize
       properties:
         id:
           type: integer
@@ -130,6 +167,12 @@ components:
         landscape:
           type: boolean
           example: true
+        minSize:
+          type: integer
+          example: 100
+        maxSize:
+          type: integer
+          example: 200
         parameters:
           type: array
           items:
@@ -203,4 +246,25 @@ components:
         maxLength:
           type: integer
           example: 100
+    PrintTemplateRequest:
+      type: object
+      required:
+        - parameterValues
+      properties:
+        parameterValues:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParameterValue"
+    ParameterValue:
+      type: object
+      required:
+        - parameterName
+        - value
+      properties:
+        parameterName:
+          type: string
+          example: address
+        value:
+          type: string
+          example: 123 Fake Street
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -22,7 +22,18 @@ paths:
           description: Template created successfully
         "404":
           description: No template found
-
+    get:
+      summary: List templates
+      operationId: ListTemplate
+      responses:
+        "200":
+          description: The template
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Template"
   /template/{id}:
     get:
       summary: Get a single template
@@ -42,7 +53,46 @@ paths:
                 $ref: "#/components/schemas/Template"
         "404":
           description: Template not found
-
+  /printer:
+    post:
+      summary: Print an image directly
+      operationId: PrintImage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - contentType
+                - data
+              properties:
+                contentType:
+                  type: string
+                  example: "image/png"
+                data:
+                  type: string
+                  format: binary
+      responses:
+        "202":
+          description: Printer successfully printed
+        "422":
+          description: Unprintable image
+        "503":
+          description: Printer unavailable
+  /printer/info:
+    get:
+      summary: Get device info
+      operationId: GetPrinterInfo
+      responses:
+        "200":
+          description: The device info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceInfo"
+        "503":
+          description: Printer unavailable
 components:
   schemas:
     DeviceInfo:
@@ -53,7 +103,7 @@ components:
         - state
       properties:
         batteryLevel:
-          type: int
+          type: integer
           description: Battery level of device as a percentage
           example: 100
         firmwareVersion:
@@ -71,6 +121,9 @@ components:
         - name
         - landscape
       properties:
+        id:
+          type: integer
+          example: 1
         name:
           type: string
           example: Postage Label

--- a/internal/server/template_mapping.go
+++ b/internal/server/template_mapping.go
@@ -10,6 +10,7 @@ import (
 
 func mapTemplateToJson(t *template.Template) *api.Template {
 	j := api.Template{
+		Id: &t.Id,
 		Name: t.Name,
 		Landscape: t.Landscape,
 	}

--- a/internal/server/template_mapping.go
+++ b/internal/server/template_mapping.go
@@ -13,6 +13,8 @@ func mapTemplateToJson(t *template.Template) *api.Template {
 		Id: &t.Id,
 		Name: t.Name,
 		Landscape: t.Landscape,
+		MinSize: t.MinSize,
+		MaxSize: t.MaxSize,
 	}
 
 	parameters := make([]api.TemplateParameter, len(t.Parameters))
@@ -41,6 +43,8 @@ func mapTemplateFromJson(j *api.Template) (*template.Template, error) {
 		Name: j.Name,
 		CreatedAt: time.Now(),
 		Landscape: j.Landscape,
+		MinSize: j.MinSize,
+		MaxSize: j.MaxSize,
 	}
 
 	if j.Parameters != nil {

--- a/internal/template/repository.go
+++ b/internal/template/repository.go
@@ -16,12 +16,12 @@ func (r *TemplateRepository) Close() error {
 
 func (r *TemplateRepository) readTemplateBase(id int) (*Template, error) {
   row := r.Db.QueryRow(`
-    SELECT name, created_at, landscape
+    SELECT name, created_at, landscape, min_size, max_size
     FROM template
     WHERE id = ?`, id)
 
   t := Template{Id: id}
-  if err := row.Scan(&t.Name, &t.CreatedAt, &t.Landscape); err != nil {
+  if err := row.Scan(&t.Name, &t.CreatedAt, &t.Landscape, &t.MinSize, &t.MaxSize); err != nil {
     if errors.Is(err, sql.ErrNoRows) {
       return nil, nil
     } else {
@@ -53,7 +53,6 @@ func (r *TemplateRepository) List() ([]Template, error) {
 	}
 
 	return templates, nil
-
 }
 
 func (r *TemplateRepository) Get(id int) (*Template, error) {
@@ -164,8 +163,8 @@ func (r *TemplateRepository) Transact(f func(*sql.Tx) error) error {
 func (r *TemplateRepository) Create(tx *sql.Tx, t *Template) error {
   row := tx.QueryRow(`
     INSERT INTO template(name, created_at, landscape, min_size, max_size)
-    VALUES (?, ?, ?, 100, 200)
-    RETURNING id`, t.Name, t.CreatedAt, t.Landscape)
+    VALUES (?, ?, ?, ?, ?)
+    RETURNING id`, t.Name, t.CreatedAt, t.Landscape, t.MinSize, t.MaxSize)
   if err := row.Scan(&t.Id); err != nil {
     return fmt.Errorf("Failed to insert into template:\n%w", err)
   }

--- a/internal/template/repository.go
+++ b/internal/template/repository.go
@@ -32,6 +32,30 @@ func (r *TemplateRepository) readTemplateBase(id int) (*Template, error) {
   return &t, nil
 }
 
+func (r *TemplateRepository) List() ([]Template, error) {
+	rows, err := r.Db.Query(`SELECT id, name, landscape FROM template`)
+	if err != nil {
+		return nil, fmt.Errorf("Query execution failed:\n%w", err)
+	}
+	defer rows.Close()
+
+	templates := []Template{}
+  for count := 0; rows.Next(); count++ {
+		t := Template{}
+		if err := rows.Scan(&t.Id, &t.Name, &t.Landscape); err != nil {
+			return nil, fmt.Errorf("row scanning failed:\n%w", err)
+		}
+		templates = append(templates, t)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("Error iterating rows:\n%w", err)
+	}
+
+	return templates, nil
+
+}
+
 func (r *TemplateRepository) Get(id int) (*Template, error) {
   t, err := r.readTemplateBase(id)
   if err != nil {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -100,7 +100,6 @@ func rotate90(img image.Image) image.Image {
 }
 
 func insertParamsIntoTemplateChildText(t *Template, params map[string]string) error {
-  fmt.Println(t.Parameters[1].Name)
   for _, tp := range t.Parameters {
     if _, exists := params[tp.Name]; !exists {
       return fmt.Errorf("No value for parameter %v", tp.Name)

--- a/main.go
+++ b/main.go
@@ -2,39 +2,28 @@ package main
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
-	"image"
-	_ "image/jpeg"
 	"log/slog"
 	"net/http"
 	"os"
 
 	"tomgalvin.uk/phogoprint/api"
 	"tomgalvin.uk/phogoprint/internal/server"
-	"tomgalvin.uk/phogoprint/internal/model"
 	"tomgalvin.uk/phogoprint/internal/printer"
 )
 
-//go:embed Banana.jpg
-var img []byte
-
 func main() {
 	fmt.Println("Hello, Phogoprint!")
+
 	r := NewRepository()
+	defer r.Close()
 
 	var conn *printer.BluetoothConnection
-	/* conn, err := printer.FromBluetoothName("T02")
+	conn, err := printer.FromBluetoothName("T02")
 	if err != nil {
 		slog.Error("Couldn't find printer", "err", err)
 		return
-	} */
-
-	// conn.Connect()
-
-	// defer conn.Disconnect()
-
-	
+	}
 
 	mux := http.NewServeMux()
 	si := server.Server{
@@ -49,73 +38,11 @@ func main() {
 
 	mux.Handle("/", http.FileServer(http.Dir("resources/web")))
 
-	mux.HandleFunc("/print", func(w http.ResponseWriter, r *http.Request) {
-		handlePrint(conn, w, r)
-	})
-
-	mux.HandleFunc("/battery", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Only GET method is supported", http.StatusMethodNotAllowed)
-			return
-		}
-		if !conn.GetPrinter().IsConnected() {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprintf(w, "Not connected")
-		} else {
-			info := conn.GetPrinter().Info()
-
-			infoData, err := json.Marshal(model.FromDeviceInfo(info))
-			if err != nil {
-				panic("fuck!")
-			}
-
-			w.WriteHeader(http.StatusOK)
-			if _, err = w.Write(infoData); err != nil {
-				slog.Error("Couldn't write HTTP response", "error", err)
-			}
-		}
-	})
-
 	port := "8080"
 	fmt.Printf("Starting server on port %s...\n", port)
 	server := http.Server{Addr:":"+port,Handler:mux}
 	if err := server.ListenAndServe(); err != nil {
 		fmt.Printf("Error starting server: %v\n", err)
 		os.Exit(1)
-	}
-}
-
-func handlePrint(p printer.Connection, w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Only POST method is supported", http.StatusMethodNotAllowed)
-		return
-	}
-
-	contentType := r.Header.Get("Content-Type")
-	if contentType != "image/png" && contentType != "image/jpeg" {
-		http.Error(w, "Invalid content type", http.StatusBadRequest)
-		return
-	}
-
-	image, format, err := image.Decode(r.Body)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Couldn't read %s data: %v", contentType, err), http.StatusBadRequest)
-		return
-	}
-	defer r.Body.Close()
-
-	fmt.Printf("Received %s image\n", format)
-
-	if err := p.Connect(); err != nil {
-		slog.Error("Couldn't connect to printer!", "error", err)
-		w.WriteHeader(http.StatusServiceUnavailable)
-	} else {
-		err = p.GetPrinter().WriteImage(image)
-
-		if err == nil {
-			w.WriteHeader(http.StatusOK)
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-		}
 	}
 }

--- a/resources/web/print.js
+++ b/resources/web/print.js
@@ -34,7 +34,7 @@ document.getElementById('text').addEventListener('input', (event) => {
 const fetchBatteryLevel = async () => {
   try {
     // Perform the POST request
-    const response = await fetch("/battery", {method: "GET"});
+    const response = await fetch("/api/printer/info", {method: "GET"});
 
     // Ensure the response is OK
     if (!response.ok) {
@@ -59,14 +59,27 @@ const updateBatteryLevel = async () => {
   document.getElementById("battery-level").innerHTML = await fetchBatteryLevel();
 };
 
+const fileToBase64 = (file) => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result.split(",")[1]); // Extract Base64
+    reader.onerror = (error) => reject(error);
+  });
+}
 const printImageServer = async (imageData, imageType) => {
   try {
-    const response = await fetch("/print", {
+    const body = {
+      "data": await fileToBase64(imageData),
+      "contentType": imageType
+    };
+    console.log(JSON.stringify(body));
+    const response = await fetch("/api/printer", {
       method: "POST",
       headers: {
         "Content-Type": imageType,
       },
-      body: imageData
+      body: JSON.stringify(body)
     });
 
     // Ensure the response is OK
@@ -76,8 +89,7 @@ const printImageServer = async (imageData, imageType) => {
       // Read the response as text
       const responseText = await response.text();
 
-      // Return or store the response as a string
-      alert(responseText);
+      alert(`HTTP ${response.status}: ${responseText}`);
     }
   } catch (error) {
     console.error("Error during POST request:", error);


### PR DESCRIPTION
Adds working functionality to print a template via the OpenAPI defined interface.

Existing manually defined APIs have been moved to the OpenAPI spec.

The API now supports:

* Create/read/list/print template
* Print image
* Get device status