### PR TITLE
Add API and rendering support for specifying font face & size

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,12 @@ type DeviceInfo struct {
 // DeviceState defines model for DeviceState.
 type DeviceState string
 
+// Font defines model for Font.
+type Font struct {
+	Name string `json:"name"`
+	Uuid Uuid   `json:"uuid"`
+}
+
 // ParameterValue defines model for ParameterValue.
 type ParameterValue struct {
 	ParameterName string `json:"parameterName"`
@@ -85,11 +91,20 @@ type TemplateParameter struct {
 
 // TemplateText defines model for TemplateText.
 type TemplateText struct {
+	FontSize int  `json:"fontSize"`
+	FontUuid Uuid `json:"fontUuid"`
+
+	// Height The max allowed height of the text. This is required if the template is landscape (landscape = `true`)
 	Height   *int     `json:"height,omitempty"`
 	Position Position `json:"position"`
 	Text     string   `json:"text"`
-	Width    *int     `json:"width,omitempty"`
+
+	// Width The max allowed width of the text. This is required if the template is portrait (landscape = `false`)
+	Width *int `json:"width,omitempty"`
 }
+
+// Uuid defines model for Uuid.
+type Uuid = string
 
 // PrintImageJSONBody defines parameters for PrintImage.
 type PrintImageJSONBody struct {
@@ -108,6 +123,9 @@ type PrintTemplateJSONRequestBody = PrintTemplateRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// List fonts
+	// (GET /font)
+	ListFont(w http.ResponseWriter, r *http.Request)
 	// Print an image directly
 	// (POST /printer)
 	PrintImage(w http.ResponseWriter, r *http.Request)
@@ -136,6 +154,20 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListFont operation middleware
+func (siw *ServerInterfaceWrapper) ListFont(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListFont(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // PrintImage operation middleware
 func (siw *ServerInterfaceWrapper) PrintImage(w http.ResponseWriter, r *http.Request) {
@@ -363,6 +395,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc("GET "+options.BaseURL+"/font", wrapper.ListFont)
 	m.HandleFunc("POST "+options.BaseURL+"/printer", wrapper.PrintImage)
 	m.HandleFunc("GET "+options.BaseURL+"/printer/info", wrapper.GetPrinterInfo)
 	m.HandleFunc("GET "+options.BaseURL+"/template", wrapper.ListTemplate)
@@ -371,6 +404,22 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/template/{id}/print", wrapper.PrintTemplate)
 
 	return m
+}
+
+type ListFontRequestObject struct {
+}
+
+type ListFontResponseObject interface {
+	VisitListFontResponse(w http.ResponseWriter) error
+}
+
+type ListFont200JSONResponse []Font
+
+func (response ListFont200JSONResponse) VisitListFontResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type PrintImageRequestObject struct {
@@ -540,6 +589,9 @@ func (response PrintTemplate503Response) VisitPrintTemplateResponse(w http.Respo
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// List fonts
+	// (GET /font)
+	ListFont(ctx context.Context, request ListFontRequestObject) (ListFontResponseObject, error)
 	// Print an image directly
 	// (POST /printer)
 	PrintImage(ctx context.Context, request PrintImageRequestObject) (PrintImageResponseObject, error)
@@ -587,6 +639,30 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// ListFont operation middleware
+func (sh *strictHandler) ListFont(w http.ResponseWriter, r *http.Request) {
+	var request ListFontRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListFont(ctx, request.(ListFontRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListFont")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListFontResponseObject); ok {
+		if err := validResponse.VisitListFontResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // PrintImage operation middleware

--- a/api/api.go
+++ b/api/api.go
@@ -85,7 +85,7 @@ type TemplateImage struct {
 
 // TemplateParameter defines model for TemplateParameter.
 type TemplateParameter struct {
-	MaxLength int    `json:"maxLength"`
+	MaxLength *int   `json:"maxLength,omitempty"`
 	Name      string `json:"name"`
 }
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -27,13 +27,26 @@ paths:
       operationId: ListTemplate
       responses:
         "200":
-          description: The template
+          description: All templates
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Template"
+  /font:
+    get:
+      summary: List fonts
+      operationId: ListFont
+      responses:
+        "200":
+          description: The fonts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Font"
   /template/{id}:
     get:
       summary: Get a single template
@@ -210,6 +223,8 @@ components:
       required:
         - text
         - position
+        - fontUuid
+        - fontSize
       properties:
         text:
           type: string
@@ -218,10 +233,17 @@ components:
           $ref: "#/components/schemas/Position"
         width:
           type: integer
+          description: The max allowed width of the text. This is required if the template is portrait (landscape = `false`)
           example: 100
         height:
           type: integer
+          description: The max allowed height of the text. This is required if the template is landscape (landscape = `true`)
           example: 100
+        fontUuid:
+          $ref: "#/components/schemas/Uuid"
+        fontSize:
+          type: integer
+          example: 20
     Position:
       type: object
       required:
@@ -267,4 +289,18 @@ components:
         value:
           type: string
           example: 123 Fake Street
-
+    Uuid:
+      type: string
+      pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
+      example: 4d98c9b6-8bb5-492d-9789-a2bb5ea8ab21
+    Font:
+      type: object
+      required:
+        - uuid
+        - name
+      properties:
+        uuid:
+          $ref: "#/components/schemas/Uuid"
+        name:
+          type: string
+          example: Go Regular

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -260,7 +260,6 @@ components:
       type: object
       required:
         - name
-        - maxLength
       properties:
         name:
           type: string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,19 @@ func (s *Server) PrintTemplate(ctx context.Context, request api.PrintTemplateReq
 	}
 }
 
+func (s *Server) ListFont(ctx context.Context, request api.ListFontRequestObject) (api.ListFontResponseObject, error) {
+	fs, err := s.TemplateRepository.ListFonts()
+	if err != nil {
+		panic(err)
+	}
+	fsJson := make([]api.Font, len(fs))
+	for i := 0; i < len(fs); i++ {
+		fsJson[i].Name = fs[i].Name
+		fsJson[i].Uuid = fs[i].Uuid.String()
+	}
+	return api.ListFont200JSONResponse(fsJson), nil
+}
+
 func (s *Server) GetPrinterInfo(ctx context.Context, request api.GetPrinterInfoRequestObject) (api.GetPrinterInfoResponseObject, error) {
 	if !s.Connection.GetPrinter().IsConnected() {
 		return api.GetPrinterInfo503Response{}, nil
@@ -157,7 +170,7 @@ func (s *Server) ListTemplate(ctx context.Context, request api.ListTemplateReque
 func (s *Server) CreateTemplate(ctx context.Context, request api.CreateTemplateRequestObject) (api.CreateTemplateResponseObject, error) {
 	r := s.TemplateRepository
 
-	t, err := mapTemplateFromJson(request.Body)
+	t, err := s.mapTemplateFromJson(request.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/template_mapping.go
+++ b/internal/server/template_mapping.go
@@ -77,12 +77,14 @@ func (s *Server) mapTemplateFromJson(j *api.Template) (*template.Template, error
 
 func mapParameterToJson(src *template.Parameter, dest *api.TemplateParameter) {
 	dest.Name = src.Name
-	dest.MaxLength = src.MaxLength
+	dest.MaxLength = &src.MaxLength
 }
 
 func mapParameterFromJson(src *api.TemplateParameter, dest *template.Parameter) {
 	dest.Name = src.Name
-	dest.MaxLength = src.MaxLength
+	if src.MaxLength != nil {
+		dest.MaxLength = *src.MaxLength
+	}
 }
 
 func mapTextToJson(src *template.Text, dest *api.TemplateText) {

--- a/internal/template/loading.go
+++ b/internal/template/loading.go
@@ -28,7 +28,7 @@ func loadImagesForTemplate(t *Template) error {
 
 func loadFontsForTemplate(t *Template) error {
 	for i := 0; i < len(t.Texts); i++ {
-		loadedFontFace, err := loadFont(&t.Texts[i].Font)
+		loadedFontFace, err := loadFont(&t.Texts[i].Font, t.Texts[i].FontSize)
 		if err != nil {
 			return fmt.Errorf("Couldn't load font for template text at index %v:\n%w", i, err)
 		}
@@ -52,7 +52,7 @@ func getFontData(f *Font) ([]byte, error) {
 	}
 }
 
-func loadFont(f *Font) (font.Face, error) {
+func loadFont(f *Font, size int) (font.Face, error) {
 	fontData, err := getFontData(f)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get font data:\n%w", err)
@@ -63,7 +63,7 @@ func loadFont(f *Font) (font.Face, error) {
 	}
 
 	fontFace, err := opentype.NewFace(parsedFont, &opentype.FaceOptions{
-		Size:    24,
+		Size:    float64(size),
 		DPI:     72,
 		Hinting: font.HintingFull,
 	})

--- a/internal/template/loading.go
+++ b/internal/template/loading.go
@@ -8,48 +8,68 @@ import (
 	_ "image/png"
 
 	"golang.org/x/image/font"
-	// "golang.org/x/image/font/gofont/goregular"
-  "golang.org/x/image/font/gofont/gomono"
+	"golang.org/x/image/font/gofont/gomono"
+	"golang.org/x/image/font/gofont/goregular"
+
 	"golang.org/x/image/font/opentype"
 )
 
 func loadImagesForTemplate(t *Template) error {
-  for i := 0; i < len(t.Images); i++ {
-    reader := bytes.NewReader(t.Images[i].Image)
-    loadedImage, _, err := image.Decode(reader)
-    if err != nil {
-      return fmt.Errorf("Couldn't load image for template image at index %v:\n%w", i, err)
-    }
-    t.Images[i].LoadedImage = loadedImage
-  }
-  return nil
+	for i := 0; i < len(t.Images); i++ {
+		reader := bytes.NewReader(t.Images[i].Image)
+		loadedImage, _, err := image.Decode(reader)
+		if err != nil {
+			return fmt.Errorf("Couldn't load image for template image at index %v:\n%w", i, err)
+		}
+		t.Images[i].LoadedImage = loadedImage
+	}
+	return nil
 }
 
 func loadFontsForTemplate(t *Template) error {
-  for i := 0; i < len(t.Texts); i++ {
-    loadedFontFace, err := loadDefaultFont()
-    if err != nil {
-      return fmt.Errorf("Couldn't load font for template text at index %v:\n%w", i, err)
-    }
-    t.Texts[i].FontFace = loadedFontFace
-  }
-  return nil
+	for i := 0; i < len(t.Texts); i++ {
+		loadedFontFace, err := loadFont(&t.Texts[i].Font)
+		if err != nil {
+			return fmt.Errorf("Couldn't load font for template text at index %v:\n%w", i, err)
+		}
+		t.Texts[i].FontFace = loadedFontFace
+	}
+	return nil
 }
 
-func loadDefaultFont() (font.Face, error) {
-  parsedFont, err := opentype.Parse(gomono.TTF)
-	if err != nil {
-    return nil, fmt.Errorf("Couldn't parse font:\n%w", err)
+func getFontData(f *Font) ([]byte, error) {
+	if len(f.BuiltinName) > 0 {
+		switch f.BuiltinName {
+		case "gomono":
+			return gomono.TTF, nil
+		case "goregular":
+			return goregular.TTF, nil
+		default:
+			return nil, fmt.Errorf(`Unrecognised default font "%s"`, f.BuiltinName)
+		}
+	} else {
+		return f.FontData, nil
 	}
-  
-  fontFace, err := opentype.NewFace(parsedFont, &opentype.FaceOptions{
-    Size: 24,
-    DPI: 72,
-    Hinting: font.HintingFull,
-  })
-  if err != nil {
-    return nil, fmt.Errorf("Couldn't create font face:\n%w", err)
-  }
+}
+
+func loadFont(f *Font) (font.Face, error) {
+	fontData, err := getFontData(f)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get font data:\n%w", err)
+	}
+	parsedFont, err := opentype.Parse(fontData)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't parse font %s (%s):\n%w", f.Name, f.Uuid.String(), err)
+	}
+
+	fontFace, err := opentype.NewFace(parsedFont, &opentype.FaceOptions{
+		Size:    24,
+		DPI:     72,
+		Hinting: font.HintingFull,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't create font face:\n%w", err)
+	}
 
 	return fontFace, nil
 }

--- a/internal/template/rendering.go
+++ b/internal/template/rendering.go
@@ -81,8 +81,6 @@ func measureAndDrawChildText(text *Text, i *image.RGBA64) Measure {
     for _, line := range wrappedText {
       d.Dot.X = fixed.I(m.X)
       d.Dot.Y += text.FontFace.Metrics().Ascent
-      fmt.Println(line)
-      fmt.Println(d.Dot)
       d.DrawString(line)
       d.Dot.Y += text.FontFace.Metrics().Descent
     }

--- a/internal/template/rendering.go
+++ b/internal/template/rendering.go
@@ -34,7 +34,7 @@ func wrapText(text string, maxWidth int, face font.Face) []string {
 
 		// Measure text width
 		width := font.MeasureString(face, testLine).Ceil()
-		if width > maxWidth && len(line) > 0 {
+		if width > maxWidth && len(line) > 0 && maxWidth > 0 {
 			lines = append(lines, line)
 			line = word
 		} else {

--- a/internal/template/repository.go
+++ b/internal/template/repository.go
@@ -1,9 +1,11 @@
 package template
 
 import (
-  "database/sql"
-  "errors"
-  "fmt"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
 )
 
 type TemplateRepository struct {
@@ -30,6 +32,55 @@ func (r *TemplateRepository) readTemplateBase(id int) (*Template, error) {
   }
 
   return &t, nil
+}
+
+func (r *TemplateRepository) ListFonts() ([]Font, error) {
+	rows, err := r.Db.Query(`
+	  SELECT uuid, name, builtin_name, font_data
+		FROM font`)
+
+	if err != nil {
+		return nil, fmt.Errorf("Query execution failed:\n%w", err)
+	}
+	defer rows.Close()
+
+	fonts := []Font{}
+  for count := 0; rows.Next(); count++ {
+		f := Font{}
+		var uuidString string
+		if err := rows.Scan(&uuidString, &f.Name, &f.BuiltinName, &f.FontData); err != nil {
+			return nil, fmt.Errorf("Row scanning failed:\n%w", err)
+		}
+		f.Uuid = uuid.MustParse(uuidString)
+		fonts = append(fonts, f)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("Error iterating rows:\n%w", err)
+	}
+
+	return fonts, nil
+}
+
+func (r *TemplateRepository) GetFont(u uuid.UUID) (*Font, error) {
+	row := r.Db.QueryRow(`
+	  SELECT uuid, name, builtin_name, font_data
+		FROM font
+		WHERE uuid = ?:0`, u.String())
+
+	var f Font
+
+	var uuidString string
+	if err := row.Scan(&uuidString, &f.Name, &f.BuiltinName, &f.FontData); err != nil {
+    if errors.Is(err, sql.ErrNoRows) {
+      return nil, nil
+    } else {
+      return nil, fmt.Errorf("Failed to read font:\n%w", err)
+    }
+	}
+	f.Uuid = uuid.MustParse(uuidString)
+
+	return &f, nil
 }
 
 func (r *TemplateRepository) List() ([]Template, error) {
@@ -100,10 +151,16 @@ func (r *TemplateRepository) Get(id int) (*Template, error) {
 
   t.Texts = make([]Text, textCount)
   if err := QueryAndScanRows(r.Db, `
-    SELECT id, text, x, y, width, height
-    FROM template_text
-    WHERE template_id = ?`, id, t.Texts, func(r *sql.Rows, i *Text) error {
-      return r.Scan(&i.Id, &i.Text, &i.X, &i.Y, &i.Width, &i.Height)
+    SELECT id, t.text, t.x, t.y, t.width, t.height, t.font_size, f.uuid, f.name, f.builtin_name, f.font_data
+    FROM template_text t
+		JOIN font f ON f.id = t.font_id
+    WHERE t.template_id = ?`, id, t.Texts, func(r *sql.Rows, i *Text) error {
+			var uuidString string
+			err := r.Scan(
+				&i.Id, &i.Text, &i.X, &i.Y, &i.Width, &i.Height, &i.FontSize,
+				&uuidString, &i.Font.Name, &i.Font.BuiltinName, &i.Font.FontData)
+			i.Font.Uuid = uuid.MustParse(uuidString)
+			return err
     },
   ); err != nil {
     return nil, fmt.Errorf("Failed to read child texts for image:\n%w", err)
@@ -236,8 +293,8 @@ func (r *TemplateRepository) insertChildren(tx *sql.Tx, t *Template) error {
   }
 
   tStmt, err := tx.Prepare(`
-    INSERT INTO template_text(template_id, text, x, y, width, height)
-    VALUES (?, ?, ?, ?, ?, ?)`)
+    INSERT INTO template_text(template_id, text, x, y, width, height, font_size, font_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, (SELECT id FROM font WHERE uuid = ?))`)
   if err != nil {
     return fmt.Errorf("Failed to prepare statement to insert template text:\n%w", err)
   }
@@ -248,6 +305,8 @@ func (r *TemplateRepository) insertChildren(tx *sql.Tx, t *Template) error {
       txt.X, txt.Y,
       txt.Width,
       txt.Height,
+			txt.FontSize,
+			txt.Font.Uuid.String(),
     )
     if err != nil {
       return fmt.Errorf("Failed to insert parameter %v of text:\n%w", i, err)

--- a/resources/sql/schema.sql
+++ b/resources/sql/schema.sql
@@ -34,5 +34,20 @@ CREATE TABLE IF NOT EXISTS template_text(
   y INT NOT NULL,
   width INT NOT NULL,
   height INT NOT NULL,
+  font_id INT NOT NULL,
+  font_size INT NOT NULL,
   FOREIGN KEY (template_id) REFERENCES template(id)
 );
+
+CREATE TABLE IF NOT EXISTS font(
+  id INTEGER PRIMARY KEY,
+  uuid TEXT NOT NULL UNIQUE CHECK (LENGTH(uuid) = 36),
+  name TEXT NOT NULL,
+  builtin_name TEXT,
+  font_data BLOB
+);
+
+INSERT INTO font(id, uuid, name, builtin_name) VALUES
+  (1, '4d98c9b6-8bb5-492d-9789-a2bb5ea8ab21', 'Go Regular', 'goregular'),
+  (2, '703d9944-d746-431a-8df8-ecf61a1e5dad', 'Go Mono', 'gomono')
+ON CONFLICT DO NOTHING;

--- a/resources/web/print.js
+++ b/resources/web/print.js
@@ -107,7 +107,7 @@ document.getElementById("idButton").onclick = async() => {
   await printCanvas();
 };
 
-const batteryInterval = setInterval(updateBatteryLevel, 1000);
+const batteryInterval = setInterval(updateBatteryLevel, 100000);
 
 document.addEventListener("DOMContentLoaded", updateBatteryLevel);
 


### PR DESCRIPTION
* Add a DB table `font` for storing fonts by UUID. Schema supports some builtin fonts (currently `gomono` and `goregular`) which are loaded directly from the go packages, and also supports storing the font data payload in the DB as a blob for e.g. font uploads from the UI.
* `template_text` updated to specify the font size and font ID referencing `font`.
* Rendering code updated to use the font data from the DB.
* API updated to specify the font UUID when creating a template with a text element

## Example

### Create template

`POST http://localhost:8080/api/template`
```json
{
  "name": "Test Template",
  "landscape": false,
  "minSize": 150,
  "texts": [
    {
      "text": "My Label",
      "position": { "x": 3, "y": 3 },
      "fontSize": 20,
      "fontUuid": "4d98c9b6-8bb5-492d-9789-a2bb5ea8ab21"
    },
    {
      "text": "Text: {text}",
      "position": { "x": 3, "y": 30 },
      "fontSize": 14,
      "fontUuid": "4d98c9b6-8bb5-492d-9789-a2bb5ea8ab21"
    },
  ],
  "parameters": [
    {
      "name": "text"
    }
  ]
}
```

### Print

`POST http://localhost:8080/api/template/3/print`
```json
{
  "parameterValues": [{"parameterName": "text", "value": "This is some text"}]
}
```

### Outcome

<img width="500" alt="Printer prints a label saying 'My Label' and 'Text: this is some text'" src="https://github.com/user-attachments/assets/42d1b7e3-c134-4a79-8744-2d2d8b8a39b1" />
