### PR TITLE
Refer to templates by UUID; add update operation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -565,12 +565,13 @@ func (response CreateOrUpdateTemplate201JSONResponse) VisitCreateOrUpdateTemplat
 	return json.NewEncoder(w).Encode(response)
 }
 
-type CreateOrUpdateTemplate400Response struct {
-}
+type CreateOrUpdateTemplate400JSONResponse string
 
-func (response CreateOrUpdateTemplate400Response) VisitCreateOrUpdateTemplateResponse(w http.ResponseWriter) error {
+func (response CreateOrUpdateTemplate400JSONResponse) VisitCreateOrUpdateTemplateResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
-	return nil
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type CreateOrUpdateTemplate404Response struct {

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8,20 +8,6 @@ servers:
 
 paths:
   /template:
-    post:
-      summary: Create a new template
-      operationId: CreateTemplate
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Template"
-      responses:
-        "201":
-          description: Template created successfully
-        "404":
-          description: No template found
     get:
       summary: List templates
       operationId: ListTemplate
@@ -40,23 +26,23 @@ paths:
       operationId: ListFont
       responses:
         "200":
-          description: The fonts
+          description: All available fonts
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Font"
-  /template/{id}:
+  /template/{uuid}:
     get:
       summary: Get a single template
       operationId: GetTemplate
       parameters:
-        - name: id
+        - name: uuid
           in: path
           required: true
           schema:
-            type: integer
+            $ref: "#/components/schemas/Uuid"
       responses:
         "200":
           description: The template
@@ -64,18 +50,52 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Template"
+        "400":
+          description: Invalid UUID
         "404":
           description: Template not found
-  /template/{id}/print:
+    put:
+      summary: Create a new template, or update an existing one
+      operationId: CreateOrUpdateTemplate
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Uuid"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Template"
+      responses:
+        "200":
+          description: Template updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Uuid"
+        "201":
+          description: Template created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Uuid"
+        "400":
+          description: Invalid UUID
+        "404":
+          description: No template found
+  /template/{uuid}/print:
     post:
       summary: Print a template
       operationId: PrintTemplate
       parameters:
-        - name: id
+        - name: uuid
           in: path
           required: true
           schema:
-            type: integer
+            $ref: "#/components/schemas/Uuid"
       requestBody:
         required: true
         content:
@@ -85,6 +105,8 @@ paths:
       responses:
         "202":
           description: Printer successfully printed
+        "400":
+          description: Invalid UUID
         "404":
           description: No such template
         "422":
@@ -166,14 +188,14 @@ components:
     Template:
       type: object
       required:
+        - uuid
         - name
         - landscape
         - minSize
         - maxSize
       properties:
-        id:
-          type: integer
-          example: 1
+        uuid:
+          $ref: "#/components/schemas/Uuid"
         name:
           type: string
           example: Postage Label

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -83,7 +83,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/Uuid"
         "400":
-          description: Invalid UUID
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Invalid UUID
         "404":
           description: No template found
   /template/{uuid}/print:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -191,11 +191,14 @@ func (s *Server) CreateOrUpdateTemplate(ctx context.Context, request api.CreateO
 
 	u, err := uuid.Parse(request.Uuid)
 	if err != nil {
-		return api.CreateOrUpdateTemplate400Response{}, nil
+		return api.CreateOrUpdateTemplate400JSONResponse("Invalid UUID"), nil
 	}
 	t, err := s.mapTemplateFromJson(request.Body)
 	if err != nil {
 		return nil, err
+	}
+	if u != t.Uuid {
+		return api.CreateOrUpdateTemplate400JSONResponse("Cannot change UUID of template"), nil
 	}
 	var exists bool
 	err = r.Transact(func(tx *sql.Tx) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 
+	"github.com/google/uuid"
 	"tomgalvin.uk/phogoprint/api"
 	"tomgalvin.uk/phogoprint/internal/printer"
 	"tomgalvin.uk/phogoprint/internal/template"
@@ -19,8 +20,17 @@ import (
 var _ api.StrictServerInterface = (*Server)(nil)
 
 type Server struct {
+	Log                *slog.Logger
 	Connection         printer.Connection
 	TemplateRepository *template.TemplateRepository
+}
+
+func NewServer(log *slog.Logger, conn printer.Connection, repo *template.TemplateRepository) *Server {
+	return &Server{
+		Log: log,
+		Connection: conn,
+		TemplateRepository: repo,
+	}
 }
 
 func (s *Server) PrintImage(ctx context.Context, request api.PrintImageRequestObject) (api.PrintImageResponseObject, error) {
@@ -36,12 +46,12 @@ func (s *Server) PrintImage(ctx context.Context, request api.PrintImageRequestOb
 	fmt.Printf("Received %s image\n", format)
 
 	if err := s.Connection.Connect(); err != nil {
-		slog.Error("Couldn't connect to printer", "error", err)
+		s.Log.Error("Couldn't connect to printer", "error", err)
 		return api.PrintImage503Response{}, nil
 	} else {
 		err = s.Connection.GetPrinter().WriteImage(image)
 		if err != nil {
-			slog.Error("Couldn't write image to printer", "error", err)
+			s.Log.Error("Couldn't write image to printer", "error", err)
 			return api.PrintImage503Response{}, nil
 		}
 
@@ -51,7 +61,11 @@ func (s *Server) PrintImage(ctx context.Context, request api.PrintImageRequestOb
 
 func (s *Server) PrintTemplate(ctx context.Context, request api.PrintTemplateRequestObject) (api.PrintTemplateResponseObject, error) {
 	r := s.TemplateRepository
-	t, err := r.Get(request.Id)
+	u, err := uuid.Parse(request.Uuid)
+	if err != nil {
+		return api.PrintTemplate400Response{}, nil
+	}
+	t, err := r.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't fetch template:\n%w", err)
 	}
@@ -86,12 +100,12 @@ func (s *Server) PrintTemplate(ctx context.Context, request api.PrintTemplateReq
 	}
 
 	if err := s.Connection.Connect(); err != nil {
-		slog.Error("Couldn't connect to printer", "error", err)
+		s.Log.Error("Couldn't connect to printer", "error", err)
 		return api.PrintTemplate503Response{}, nil
 	} else {
 		err = s.Connection.GetPrinter().WriteImage(img)
 		if err != nil {
-			slog.Error("Couldn't write image to printer", "error", err)
+			s.Log.Error("Couldn't write image to printer", "error", err)
 			return api.PrintTemplate503Response{}, nil
 		}
 
@@ -144,7 +158,12 @@ func mapDeviceStateToJson(s printer.DeviceState) api.DeviceState {
 
 func (s *Server) GetTemplate(ctx context.Context, request api.GetTemplateRequestObject) (api.GetTemplateResponseObject, error) {
 	r := s.TemplateRepository
-	t, err := r.Get(request.Id)
+
+	u, err := uuid.Parse(request.Uuid)
+	if err != nil {
+		return api.GetTemplate400Response{}, nil
+	}
+	t, err := r.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't fetch template:\n%w", err)
 	}
@@ -167,18 +186,37 @@ func (s *Server) ListTemplate(ctx context.Context, request api.ListTemplateReque
 	return api.ListTemplate200JSONResponse(tsJson), nil
 }
 
-func (s *Server) CreateTemplate(ctx context.Context, request api.CreateTemplateRequestObject) (api.CreateTemplateResponseObject, error) {
+func (s *Server) CreateOrUpdateTemplate(ctx context.Context, request api.CreateOrUpdateTemplateRequestObject) (api.CreateOrUpdateTemplateResponseObject, error) {
 	r := s.TemplateRepository
 
+	u, err := uuid.Parse(request.Uuid)
+	if err != nil {
+		return api.CreateOrUpdateTemplate400Response{}, nil
+	}
 	t, err := s.mapTemplateFromJson(request.Body)
 	if err != nil {
 		return nil, err
 	}
+	var exists bool
 	err = r.Transact(func(tx *sql.Tx) error {
-		return r.Create(tx, t)
+		if exists, err = r.Exists(u); err == nil {
+			if exists {
+				s.Log.Info("Updating template", "uuid", request.Uuid)
+				return r.Update(tx, u, t)
+			} else {
+				s.Log.Info("Creating template", "uuid", request.Uuid)
+				return r.Create(tx, t)
+			}
+		} else {
+			return err
+		}
 	})
 	if err != nil {
 		return nil, err
 	}
-	return api.CreateTemplate201Response{}, nil
+	if exists {
+		return api.CreateOrUpdateTemplate200JSONResponse(request.Uuid), nil
+	} else {
+		return api.CreateOrUpdateTemplate201JSONResponse(request.Uuid), nil
+	}
 }

--- a/internal/server/template_mapping.go
+++ b/internal/server/template_mapping.go
@@ -12,7 +12,7 @@ import (
 
 func mapTemplateToJson(t *template.Template) *api.Template {
 	j := api.Template{
-		Id: &t.Id,
+		Uuid: t.Uuid.String(),
 		Name: t.Name,
 		Landscape: t.Landscape,
 		MinSize: t.MinSize,
@@ -40,8 +40,12 @@ func mapTemplateToJson(t *template.Template) *api.Template {
 }
 
 func (s *Server) mapTemplateFromJson(j *api.Template) (*template.Template, error) {
+	uuid, err := uuid.Parse(j.Uuid)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid UUID:\n%w", err)
+	}
 	t := template.Template{
-		Id: 0,
+		Uuid: uuid,
 		Name: j.Name,
 		CreatedAt: time.Now(),
 		Landscape: j.Landscape,
@@ -123,7 +127,7 @@ func (s *Server) mapTextFromJson(src *api.TemplateText, dest *template.Text) err
 		return fmt.Errorf("Couldn't load font:\n%w", err)
 	}
 	if f == nil {
-		return fmt.Errorf("Font UUID does not exist:\n%w", f)
+		return fmt.Errorf("Font UUID does not exist: %s", src.FontUuid)
 	}
 
 	dest.Font = *f

--- a/internal/template/repository.go
+++ b/internal/template/repository.go
@@ -258,7 +258,7 @@ func (r *TemplateRepository) Update(tx *sql.Tx, u uuid.UUID, t *Template) error 
   if tFromDb == nil {
     return fmt.Errorf("No template with UUID %s", u.String())
   }
-	
+
 	t.Id = tFromDb.Id
 	if err := r.Multi(tx, t.Id,
 		  "DELETE FROM template_parameter WHERE template_id = ?",

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -14,6 +14,7 @@ import (
 
 type Template struct {
 	Id               int
+	Uuid             uuid.UUID
 	Name             string
 	CreatedAt        time.Time
 	Landscape        bool

--- a/main.go
+++ b/main.go
@@ -26,11 +26,9 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	si := server.Server{
-		TemplateRepository: r,
-		Connection:         conn,
-	}
-	sh := api.NewStrictHandler(&si, nil)
+	logger := slog.Default()
+	si := server.NewServer(logger.With("src", "server"), conn, r)
+	sh := api.NewStrictHandler(si, nil)
 	h := http.StripPrefix("/api", api.Handler(sh))
 
 

--- a/resources/sql/schema.sql
+++ b/resources/sql/schema.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS template(
   id INTEGER PRIMARY KEY,
+  uuid TEXT NOT NULL UNIQUE CHECK (LENGTH(uuid) = 36),
   name TEXT NOT NULL,
   created_at TIMESTAMP NOT NULL,
   landscape INT NOT NULL, -- boolean


### PR DESCRIPTION
* Assign UUIDs to templates rather than using numeric ID
* Change creation API to use `PUT` rather than `POST`; also updates existing template if it exists so it's fully idempotent
* Use `slog` instance in `Server`
* Fix `TemplateRepository.Update()` implementation